### PR TITLE
Add adbTimeout to spoon plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,4 +57,5 @@ android {
 
 spoon {
     debug = true;
+    adbTimeout = 30;
 }


### PR DESCRIPTION
without this setting, ./gradlew spoon will throw an error
